### PR TITLE
Replace MAINTAINERS.md by CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+# vpn maintainers
+* 	@rfranzke @dkistner

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,4 +1,0 @@
-Maintainers of this repository:
-
-* Rafael Franzke <rafael.franzke@sap.com> @rfranzke
-* Dominic Kistner <dominic.kistner@sap.com> @dkistner


### PR DESCRIPTION
This enables use of the Github codeowners feature
https://help.github.com/articles/about-codeowners/