### PR TITLE
post release notes to internal slack channel

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -33,5 +33,11 @@ vpn:
           preprocess: 'finalize'
         release:
           nextversion: 'bump_minor'
+        slack:
+          default_channel: 'internal_scp_workspace'
+          channel_cfgs:
+            internal_scp_workspace:
+              channel_name: 'k8s-gardener'
+              slack_cfg_name: 'scp_workspace'
         component_descriptor:
           component_name: 'github.com/gardener/vpn'


### PR DESCRIPTION
**What this PR does / why we need it**:
On a new release of the vpn component, the release notes should be published to the internal slack channel `k8s-gardener`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We have requested a [slack bot](https://kubernetes.slack.com/apps/A0F7YS25R-bots?next_id=0) on the `Kubernetes` workspace to publish release notes to the public `gardener` channel but it was rejected by one of the Kubernetes slack admins.  

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```improvement operator
NONE
```
