### PR TITLE
Bump alpine version to 3.8

### DIFF
--- a/seed/Dockerfile
+++ b/seed/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN apk add --update bash curl openvpn jq && \
     rm -rf /var/cache/apk/*

--- a/shoot/Dockerfile
+++ b/shoot/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM alpine:3.7
+FROM alpine:3.8
 
 RUN apk add --update bash curl openvpn iptables bc && \
     rm -rf /var/cache/apk/*


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump outdated alpine to 3.8

**Which issue(s) this PR fixes**:

Possible security vulnerability in OpenVPN (which however does not appear to be exploitable in this context)

**Special notes for your reviewer**:

**Release note**:

```noteworthy operator
The alpine base image version has been updated to `3.8`.
```
