### PR TITLE
Enable vpn-shoot to read config from files

### DIFF
--- a/shoot/network-connection.sh
+++ b/shoot/network-connection.sh
@@ -20,9 +20,21 @@ function log() {
 
 trap 'exit' TERM SIGINT
 
-service_network="${SERVICE_NETWORK:-100.64.0.0/13}"
-pod_network="${POD_NETWORK:-100.96.0.0/11}"
-node_network="${NODE_NETWORK:-10.250.0.0/16}"
+# for each cidr config, it looks first at its env var, then a local file (which may be a volume mount), then the default
+baseConfigDir="/init-config"
+fileServiceNetwork=
+filePodNetwork=
+fileNodeNetwork=
+[ -e "${baseConfigDir}/serviceNetwork" ] && fileServiceNetwork=$(cat ${baseConfigDir}/serviceNetwork)
+[ -e "${baseConfigDir}/podNetwork" ] && filePodNetwork=$(cat ${baseConfigDir}/podNetwork)
+[ -e "${baseConfigDir}/nodeNetwork" ] && fileNodeNetwork=$(cat ${baseConfigDir}/nodeNetwork)
+
+service_network="${SERVICE_NETWORK:-${fileServiceNetwork}}"
+service_network="${service_network:-100.64.0.0/13}"
+pod_network="${POD_NETWORK:-${filePodNetwork}}"
+pod_network="${pod_network:-100.96.0.0/11}"
+node_network="${NODE_NETWORK:-${fileNodeNetwork}}"
+node_network="${node_network:-10.250.0.0/16}"
 
 # calculate netmask for given CIDR (required by openvpn)
 #


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables vpn-shoot to read its config from files in `/init-config/` in addition to env vars. Follow-up to https://github.com/gardener/gardener/pull/798 as discussed with @rfranzke . 

Order of priority:

1. env var
2. file
3. default in `network-connection.sh`

Previous order of priority:

1. env var
2. default in `network-connection.sh`

**Special notes for your reviewer**:

Continuation of https://github.com/gardener/gardener/pull/798 . That PR enabled the insertion of the config into the manifest and to run InitContainers that could populate `/init-config/`; this PR enables the vpn-shoot to consume those.

Final PR in this series will be adding documentation about how to use it once this is in.


**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->

```improvement operator
The vpn-shoot is now able to load its CIDR configuration dynamically at run-time or at build-time.
```
