### PR TITLE
Unblock OpenVPN Server range for testing

### DIFF
--- a/seed/openvpn.config.template
+++ b/seed/openvpn.config.template
@@ -47,5 +47,6 @@ remote-cert-tls server
 pull-filter accept "route ${SERVICE_NETWORK_ADDRESS} ${SERVICE_NETWORK_NETMASK}"
 pull-filter accept "route ${POD_NETWORK_ADDRESS} ${POD_NETWORK_NETMASK}"
 pull-filter accept "route ${NODE_NETWORK_ADDRESS} ${NODE_NETWORK_NETMASK}"
-pull-filter ignore "route "
+pull-filter accept "route 192.168.123."
+pull-filter ignore "route"
 pull-filter ignore redirect-gateway


### PR DESCRIPTION
**What this PR does / why we need it**:
Unblock OpenVPN Server range for testing (server 192.168.123.0 255.255.255.0)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
Prometheus checks to the VPN tun interface should now work as expected.
```
