### PR TITLE
block ipv6 route and gateway entries

### DIFF
--- a/seed/openvpn.config.template
+++ b/seed/openvpn.config.template
@@ -50,3 +50,5 @@ pull-filter accept "route ${NODE_NETWORK_ADDRESS} ${NODE_NETWORK_NETMASK}"
 pull-filter accept "route 192.168.123."
 pull-filter ignore "route"
 pull-filter ignore redirect-gateway
+pull-filter ignore route-ipv6
+pull-filter ignore redirect-gateway-ipv6


### PR DESCRIPTION
**What this PR does / why we need it**:
Blocks ipv6 route and gateway entries.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
ipv6 route and gateway entries from shoot cluster are blocked
```
