### PR TITLE
Make node network optional

### DIFF
--- a/seed/network-connection.sh
+++ b/seed/network-connection.sh
@@ -115,7 +115,7 @@ service_network="${service_network:-100.64.0.0/13}"
 pod_network="${POD_NETWORK:-${filePodNetwork}}"
 pod_network="${pod_network:-100.96.0.0/11}"
 node_network="${NODE_NETWORK:-${fileNodeNetwork}}"
-node_network="${node_network:-10.250.0.0/16}"
+node_network="${node_network:-}"
 
 # calculate netmask for given CIDR (required by openvpn)
 CIDR2Netmask() {
@@ -153,14 +153,22 @@ pod_network_netmask=$(CIDR2Netmask $pod_network)
 sed -e "s/\${SERVICE_NETWORK_ADDRESS}/${service_network_address}/" \
     -e "s/\${SERVICE_NETWORK_NETMASK}/${service_network_netmask}/" \
     -e "s/\${POD_NETWORK_ADDRESS}/${pod_network_address}/" \
-    -e "s/\${POD_NETWORK_NETMASK}/${pod_network_netmask}/" openvpn.config.template > openvpn.config
+    -e "s/\${POD_NETWORK_NETMASK}/${pod_network_netmask}/" \
+    openvpn.config.template > openvpn.config
 
-for n in $(echo $node_network |  sed 's/[][]//g' | sed 's/,/ /g')
-do
-    node_network_address=$(echo $n | cut -f1 -d/)
-    node_network_netmask=$(CIDR2Netmask $n)
-    sed -i  "49ipull-filter accept \"route ${node_network_address} ${node_network_netmask}\"" openvpn.config
-done
+if [[ ! -z "$node_network" ]]; then
+  for n in $(echo $node_network |  sed 's/[][]//g' | sed 's/,/ /g')
+  do
+      node_network_address=$(echo $n | cut -f1 -d/)
+      node_network_netmask=$(CIDR2Netmask $n)
+      echo "pull-filter accept \"route ${node_network_address} ${node_network_netmask}\"" >> openvpn.config
+  done
+fi
+
+echo "pull-filter ignore \"route\"" >> openvpn.config
+echo "pull-filter ignore redirect-gateway" >> openvpn.config
+echo "pull-filter ignore route-ipv6" >> openvpn.config
+echo "pull-filter ignore redirect-gateway-ipv6" >> openvpn.config
 
 while : ; do
     # identify_endpoint may get an invalid endpoint, need

--- a/seed/openvpn.config.template
+++ b/seed/openvpn.config.template
@@ -46,8 +46,3 @@ remote-cert-tls server
 # pull filter
 pull-filter accept "route ${SERVICE_NETWORK_ADDRESS} ${SERVICE_NETWORK_NETMASK}"
 pull-filter accept "route ${POD_NETWORK_ADDRESS} ${POD_NETWORK_NETMASK}"
-pull-filter accept "route 192.168.123."
-pull-filter ignore "route"
-pull-filter ignore redirect-gateway
-pull-filter ignore route-ipv6
-pull-filter ignore redirect-gateway-ipv6


### PR DESCRIPTION
**What this PR does / why we need it**:
Make the node network optional as not every environment/provider has the requirement to forward traffic between the seed and the shoot node network via VPN. Some providers only have one large network for all VMs, hence, here the seed workers and all shoot workers can see themselves and talk with each other always.

**Special notes for your reviewer**:
/cc @stoyanr @marin

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy
- target_group:   user|operator
-->
```noteworthy operator
It is now possible to omit the `NODE_NETWORK` environment variable for both `vpn-seed` and `vpn-shoot` in case it is not required to tunnel traffic from the seed to the shoot node network via the VPN.
```
